### PR TITLE
Updated java driver reference to use DataStax docs instead of github …

### DIFF
--- a/src/site/docs/languages/java/index.md
+++ b/src/site/docs/languages/java/index.md
@@ -132,7 +132,7 @@ KillrVideo and how the Web Tier interacts with the microservices running on your
 
 [cassandra]: http://cassandra.apache.org/
 [dse]: http://www.datastax.com/products/datastax-enterprise
-[driver]: https://github.com/datastax/java-dse-driver
+[driver]: https://docs.datastax.com/en/developer/java-driver-dse/1.8/
 [grpc]: http://www.grpc.io/
 [idea]: https://www.jetbrains.com/idea
 [eclipse]: https://www.eclipse.org/


### PR DESCRIPTION
…repo

The previously used link "https://github.com/datastax/java-dse-driver" no longer exists so switched it to use "https://docs.datastax.com/en/developer/java-driver-dse/1.8/". I also used the reference to the 1.8 driver because the current codebase uses the 1.8.2 driver.